### PR TITLE
Add handle_options property to Parser

### DIFF
--- a/spec/options_spec.lua
+++ b/spec/options_spec.lua
@@ -125,6 +125,17 @@ describe("tests related to options", function()
          assert.same({input = "foo", exclude = {}}, args)
       end)
 
+      it("does not interpret options if disabled", function()
+         local parser = Parser()
+         parser:handle_options(false)
+         parser:argument "input"
+            :args "*"
+         parser:option "-f" "--foo"
+            :args "*"
+         local args = parser:parse{"bar", "-f", "--foo" , "bar"}
+         assert.same({input = {"bar", "-f", "--foo" , "bar"}}, args)
+      end)
+
       describe("Special chars set", function()
          it("handles windows-style options", function()
             local parser = Parser()

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -183,7 +183,8 @@ local Parser = new_class({
    _options = {},
    _commands = {},
    _mutexes = {},
-   _require_command = true
+   _require_command = true,
+   _handle_options = true
 }, {
    typechecked("name", "string"),
    typechecked("description", "string"),
@@ -191,6 +192,7 @@ local Parser = new_class({
    typechecked("usage", "string"),
    typechecked("help", "string"),
    typechecked("require_command", "boolean"),
+   typechecked("handle_options", "boolean"),
    add_help
 })
 
@@ -204,6 +206,7 @@ local Command = new_class({
    typechecked("usage", "string"),
    typechecked("help", "string"),
    typechecked("require_command", "boolean"),
+   typechecked("handle_options", "boolean"),
    typechecked("action", "function"),
    add_help
 }, Parser)
@@ -673,6 +676,7 @@ function Parser:_parse(args, errhandler)
    local cur_arg_i = 1
    local cur_arg
    local targets = {}
+   local handle_options = true
 
    local function error_(fmt, ...)
       return errhandler(parser, fmt:format(...))
@@ -824,6 +828,7 @@ function Parser:_parse(args, errhandler)
          invoke(argument)
       end
 
+      handle_options = parser._handle_options
       cur_arg = arguments[cur_arg_i]
       commands = parser._commands
       com_context = {}
@@ -891,7 +896,6 @@ function Parser:_parse(args, errhandler)
    end
 
    local function mainloop()
-      local handle_options = true
 
       for _, data in ipairs(args) do
          local plain = true


### PR DESCRIPTION
When `parser:handle_options(true)` (the default), the parser will behave as
before.

When `parser:handle_options(false)`, all options will be passed verbatim
to the argument list, as if the input included double-hyphens.

Use case: I am writing a wrapper over an existing CLI tool, and I'd like to include a "passthrough" command so that any options, arguments etc. are applied directly to that tool instead of being consumed by argparse. All the other commands are handled by argparse normally.

Also, I couldn't tell if the tutorial docs were generated by a tool or not. Could you please document this change with whatever workflow you have set up?